### PR TITLE
Fix incorrect bind_param types in add_user

### DIFF
--- a/User/add_user.php
+++ b/User/add_user.php
@@ -109,7 +109,7 @@ if (!$stmt) {
    s remark
 */
 $stmt->bind_param(
-    "iiisisisisisisisissidis",
+    "iiisisisisisisisisssids",
     $user_id,
     $company_id,
     $product_id,


### PR DESCRIPTION
## Summary
- correct parameter type string when inserting transactional data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68525ccaf5ac8328b8b89f3ccb5836ae